### PR TITLE
feat: add follow symlink option

### DIFF
--- a/main.py
+++ b/main.py
@@ -73,6 +73,7 @@ class FuzzyFinderExtension(Extension):
         preferences: FuzzyFinderPreferences = {
             "search_type": SearchType(int(input_preferences["search_type"])),
             "allow_hidden": bool(int(input_preferences["allow_hidden"])),
+            "follow_symlinks": bool(int(input_preferences["follow_symlinks"])),
             "result_limit": int(input_preferences["result_limit"]),
             "base_dir": path.expanduser(input_preferences["base_dir"]),
             "ignore_file": path.expanduser(input_preferences["ignore_file"]),
@@ -92,6 +93,9 @@ class FuzzyFinderExtension(Extension):
 
         if preferences["allow_hidden"]:
             cmd.extend(["--hidden"])
+
+        if preferences["follow_symlinks"]:
+            cmd.extend(["--follow"])
 
         if preferences["ignore_file"]:
             cmd.extend(["--ignore-file", preferences["ignore_file"]])

--- a/manifest.json
+++ b/manifest.json
@@ -53,6 +53,23 @@
       ]
     },
     {
+      "id": "follow_symlinks",
+      "type": "select",
+      "name": "Follow symbolic links",
+      "description": "Set whether to follow symlinked directories.",
+      "default_value": 0,
+      "options": [
+        {
+          "text": "No",
+          "value": 0
+        },
+        {
+          "text": "Yes",
+          "value": 1
+        }
+      ]
+    },
+    {
       "id": "result_limit",
       "type": "input",
       "name": "Result limit",


### PR DESCRIPTION
Closes #30 

Adding a new option to follow symbolic links when searching for files (defaults to "No")
![image](https://user-images.githubusercontent.com/44228565/187658840-58488cf4-0978-479c-989d-c11469989bb6.png)

I changed my base dir to ulauncher-fzf working directory and created a symlink to a folder full of emojis.

When the option is disabled, I am only able to see the symlink as a result - this is the existing behaviour
![image](https://user-images.githubusercontent.com/44228565/187659849-0029d607-4793-4ec9-94dc-2c8cb1868e6b.png)

When the option is enabled, I can see emojis within the `emotes/` symlink
![image](https://user-images.githubusercontent.com/44228565/187659781-7b342f68-5f6f-4940-966a-cb285441c4c0.png)

`Enter` and `Alt-Enter` actions should work as normal
