### PR TITLE
feat: add alt+enter action selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,24 @@ Find files and directories in Ulauncher using fzf (and fd).
 * Follow symbolic links
 * Specify preferred number of results returned
 * Specify base directory to be searched
-* Ignore certain files and directories - you can do this by creating an ignore-file which follows the [`.gitignore`](https://git-scm.com/docs/gitignore#_pattern_format) format, then specify the path to ignore-file in the extension's settings.
+* Ignore certain files and directories - you can do this by creating an ignore-file
+which follows the [`.gitignore`](https://git-scm.com/docs/gitignore#_pattern_format)
+format, then specify the path to ignore-file in the extension's settings.
 
 Actions:
 
 * Click or press *"Enter"* to open
-    * file with default application
-    * directory in your file manager
-* Press *"Alt+Enter"* to open the directory in which the file is contained.  
-    If the path is a directory, this will be the same as pressing Enter
+    * a file with its default application
+    * a directory in your file manager
+* You can select your preferred action for *"Alt+Enter"*. Actions include:
+    * opening the directory in which the file is contained (default)
+    * copying the file path to your clipboard
 
 ## Development
 
-You can use command runners `make` or [`just`](https://github.com/casey/just) to run project-specific commands. Any `make` target can also be run with `just`. E.g., `make dev` or `just dev`
+You can use command runners `make` or [`just`](https://github.com/casey/just)
+to run project-specific commands. Any `make` target can also be run with `just`.
+E.g., `make dev` or `just dev`
 
 1. Clone repository.
 
@@ -39,7 +44,8 @@ You can use command runners `make` or [`just`](https://github.com/casey/just) to
     ```
 
 1. (Optional) Install developer dependencies.  
-    This is used to install dependencies for running `lint` and `format`. It will require Python 3.7 or higher and [poetry](https://python-poetry.org/docs/).
+    This is used to install dependencies for running `lint` and `format`.
+    It will require Python 3.7 or higher and [poetry](https://python-poetry.org/docs/).
 
     ```sh
     make setup

--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,23 @@
       "default_value": "fzf"
     },
     {
+      "id": "alt_enter_action",
+      "type": "select",
+      "name": "Alt+Enter action",
+      "description": "Set the preferred behaviour for Alt+Enter.",
+      "default_value": 0,
+      "options": [
+        {
+          "text": "Open path's directory",
+          "value": 0
+        },
+        {
+          "text": "Copy path to clipboard",
+          "value": 1
+        }
+      ]
+    },
+    {
       "id": "search_type",
       "type": "select",
       "name": "Search type",


### PR DESCRIPTION
Closes #33 

Add setting to select preferred action for `Alt+Enter`.

Defaults to opening selected path's directory in file browser (the existing behaviour).

Adds new action of copying the selected path to clipboard

Screenshots:

![image](https://user-images.githubusercontent.com/44228565/211806940-3b3c5e12-5b7e-4169-a0b7-4e1375109344.png)

![image](https://user-images.githubusercontent.com/44228565/211806986-faa100a5-5f22-4bda-a439-fff54e6eb610.png)

