### PR TITLE
Replace display path based on regex.

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import shutil
 import subprocess
 from enum import Enum
@@ -85,6 +86,8 @@ class FuzzyFinderExtension(Extension):
             "result_limit": int(input_preferences["result_limit"]),
             "base_dir": path.expanduser(input_preferences["base_dir"]),
             "ignore_file": path.expanduser(input_preferences["ignore_file"]),
+            "match_pattern": path.expanduser(input_preferences["match_pattern"]),
+            "match_replacement": path.expanduser(input_preferences["match_replacement"]),
         }
 
         logger.debug("Using user preferences %s", preferences)
@@ -199,7 +202,9 @@ class KeywordQueryEventListener(EventListener):
         def create_result_item(path_name: str) -> ExtensionSmallResultItem:
             return ExtensionSmallResultItem(
                 icon="images/sub-icon.png",
-                name=path_name,
+                name=re.sub(
+                    preferences["match_pattern"], preferences["match_replacement"], path_name
+                ),
                 on_enter=OpenAction(path_name),
                 on_alt_enter=self.get_alt_enter_action(preferences["alt_enter_action"], path_name),
             )

--- a/manifest.json
+++ b/manifest.json
@@ -106,6 +106,22 @@
       "name": "Path to ignore-file",
       "description": "Path to a custom ignore-file in '.gitignore' format for files or directories to ignore.",
       "default_value": ""
+    },
+    {
+      "id": "match_pattern",
+      "type": "input",
+      "name": "Pattern to match",
+      "description": "Regex pattern to match in file name (useful for stripping common prefixes; Eg: \".*\\\/\").",
+      "default_value": ""
+    },
+    {
+      "id": "match_replacement",
+      "type": "input",
+      "name": "Replacement string",
+      "description": "String to replace if matched.",
+      "default_value": ""
     }
+
+
   ]
 }


### PR DESCRIPTION
When searching from a directory, the full path is shown which is often redundant (and takes up space). This PR lets you do a regex substitution on the displayed path.