### PR TITLE
feat: trim displayed path name results

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -87,6 +87,23 @@
       ]
     },
     {
+      "id": "trim_display_path",
+      "type": "select",
+      "name": "Trim displayed path name",
+      "description": "Trim common path prefix from results. E.g. results '/path/to/filename/file1' and '/path/to/filename/file2' are displayed as '.../filename/file1' and '.../filename/file2'",
+      "default_value": 0,
+      "options": [
+        {
+          "text": "No",
+          "value": 0
+        },
+        {
+          "text": "Yes",
+          "value": 1
+        }
+      ]
+    },
+    {
       "id": "result_limit",
       "type": "input",
       "name": "Result limit",


### PR DESCRIPTION
**Problem:**

#37 mentions that search results can contain duplicate prefixes that can be redundant to users trying to users trying to understand the results

![image](https://user-images.githubusercontent.com/44228565/230751393-4a9a3eb6-0365-42c0-bfec-2c3b1570de67.png)

**Solution:**
Add a setting that allows us to trim common prefix path in the generated results. This does not affect the copied or opened file path result.

![image](https://user-images.githubusercontent.com/44228565/230751121-b6dce641-55ff-43b7-a1a6-cf499dd3185b.png)

![image](https://user-images.githubusercontent.com/44228565/230751423-0af33124-df81-420c-9b50-c3dec19db600.png)

Note that the trimmed path still includes the parent directory to provided additional context about where the resulting path is.