### PR TITLE
fix: handle Path defaults to . for empty path

### DIFF
--- a/main.py
+++ b/main.py
@@ -96,7 +96,9 @@ class FuzzyFinderExtension(Extension):
             "trim_display_path": bool(int(input_preferences["trim_display_path"])),
             "result_limit": int(input_preferences["result_limit"]),
             "base_dir": str(Path(input_preferences["base_dir"]).expanduser()),
-            "ignore_file": str(Path(input_preferences["ignore_file"]).expanduser()),
+            "ignore_file": str(Path(input_preferences["ignore_file"]).expanduser())
+            if input_preferences["ignore_file"]
+            else None,
         }
 
         errors = FuzzyFinderExtension._validate_preferences(preferences)


### PR DESCRIPTION
In #49 `ignore_file` preference was updated to be interepted via `pathlib.Path`. This has a different behaviour to `os.Path.expanduser`.

```
>>> from pathlib import Path
>>> Path('').expanduser()
PosixPath('.')
>>> from os import path
>>> path.expanduser("")
''
```

As a result, users without an ignore file experience an "Ignore file '.' is not a file" (#51)