### PR TITLE
App new option to choose result appearance

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -87,6 +87,23 @@
       ]
     },
     {
+      "id": "result_appearance",
+      "type": "select",
+      "name": "Result appearance",
+      "description": "The size in which results should be displayed",
+      "default_value": 0,
+      "options": [
+        {
+          "text": "Compact",
+          "value": 0
+        },
+        {
+          "text": "Comfortable",
+          "value": 1
+        }
+      ]
+    },
+    {
       "id": "trim_display_path",
       "type": "select",
       "name": "Trim displayed path name",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ warn_redundant_casts = true
 warn_unreachable = true
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["ALL"]

--- a/src/enums.py
+++ b/src/enums.py
@@ -10,3 +10,8 @@ class SearchType(Enum):
     BOTH = 0
     FILES = 1
     DIRS = 2
+
+
+class ResultAppearance(Enum):
+    COMPACT = 0
+    COMFORTABLE = 1

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -4,7 +4,7 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path
 
-from src.enums import AltEnterAction, SearchType
+from src.enums import AltEnterAction, ResultAppearance, SearchType
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +15,7 @@ class FuzzyFinderPreferences:
     search_type: SearchType
     allow_hidden: bool
     follow_symlinks: bool
+    result_appearance: ResultAppearance
     trim_display_path: bool
     result_limit: int
     base_dir: Path
@@ -33,6 +34,7 @@ def get_preferences(
         search_type=SearchType(int(input_preferences["search_type"])),
         allow_hidden=bool(int(input_preferences["allow_hidden"])),
         follow_symlinks=bool(int(input_preferences["follow_symlinks"])),
+        result_appearance=ResultAppearance(int(input_preferences["result_appearance"])),
         trim_display_path=bool(int(input_preferences["trim_display_path"])),
         result_limit=int(input_preferences["result_limit"]),
         base_dir=_expand_path(input_preferences["base_dir"]) or Path("~").expanduser(),

--- a/src/results.py
+++ b/src/results.py
@@ -12,7 +12,7 @@ from ulauncher.api.shared.action.RenderResultListAction import RenderResultListA
 from ulauncher.api.shared.item.ExtensionResultItem import ExtensionResultItem
 from ulauncher.api.shared.item.ExtensionSmallResultItem import ExtensionSmallResultItem
 
-from src.enums import AltEnterAction
+from src.enums import AltEnterAction, ResultAppearance
 
 if TYPE_CHECKING:
     from ulauncher.api.shared.action.BaseAction import BaseAction
@@ -47,7 +47,11 @@ def _get_path_prefix(results: list[str], trim_path: bool) -> str | None:  # noqa
     return path_prefix
 
 
-def _get_display_name(path_name: str, path_prefix: str | None = None) -> str:
+def _get_path_stem(path_name: str) -> str:
+    return Path(path_name).stem
+
+
+def _get_display_path(path_name: str, path_prefix: str | None = None) -> str:
     display_path = path_name
     if path_prefix is not None:
         display_path = path_name.replace(path_prefix, "...")
@@ -60,12 +64,26 @@ def generate_result_items(
     path_prefix = _get_path_prefix(results, preferences.trim_display_path)
 
     def create_result_item(path_name: str) -> ExtensionSmallResultItem:
-        return ExtensionSmallResultItem(
-            icon="images/sub-icon.png",
-            name=_get_display_name(path_name, path_prefix),
-            on_enter=OpenAction(path_name),
-            on_alt_enter=_get_alt_enter_action(preferences.alt_enter_action, path_name),
-        )
+        match preferences.result_appearance:
+            case ResultAppearance.COMPACT:
+                return ExtensionSmallResultItem(
+                    icon="images/sub-icon.png",
+                    name=_get_display_path(path_name, path_prefix),
+                    on_enter=OpenAction(path_name),
+                    on_alt_enter=_get_alt_enter_action(
+                        preferences.alt_enter_action, path_name
+                    ),
+                )
+            case ResultAppearance.COMFORTABLE:
+                return ExtensionResultItem(
+                    icon="images/sub-icon.png",
+                    name=_get_path_stem(path_name),
+                    description=_get_display_path(path_name, path_prefix),
+                    on_enter=OpenAction(path_name),
+                    on_alt_enter=_get_alt_enter_action(
+                        preferences.alt_enter_action, path_name
+                    ),
+                )
 
     return list(map(create_result_item, results))
 

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from src.enums import AltEnterAction, SearchType
+from src.enums import AltEnterAction, ResultAppearance, SearchType
 from src.preferences import (
     FuzzyFinderPreferences,
     get_preferences,
@@ -47,6 +47,7 @@ class TestGetPreferences:
             "search_type": SearchType.BOTH.value,
             "allow_hidden": 0,
             "follow_symlinks": 0,
+            "result_appearance": 0,
             "trim_display_path": 0,
             "result_limit": result_limit
             if result_limit is not None
@@ -65,6 +66,7 @@ class TestGetPreferences:
         assert result.search_type == SearchType.BOTH
         assert result.allow_hidden is False
         assert result.follow_symlinks is False
+        assert result.result_appearance == ResultAppearance.COMPACT
         assert result.trim_display_path is False
         assert result.result_limit == self.default_result_limit
         assert isinstance(result.base_dir, Path)
@@ -126,6 +128,7 @@ class TestValidatePreferences:
             search_type=SearchType.BOTH,
             allow_hidden=False,
             follow_symlinks=False,
+            result_appearance=ResultAppearance.COMPACT,
             trim_display_path=False,
             result_limit=result_limit if result_limit is not None else 15,
             base_dir=self.mock_base_dir,


### PR DESCRIPTION
#111 highlights readability issues that come from using `ExtensionSmallResultItem`.

This PR introduces a result appearance setting, which allows users to choose between a compact and comfortable result appearance.

<img width="893" height="176" alt="image" src="https://github.com/user-attachments/assets/96a3ac7e-2569-4581-ad52-77cd1b1ad028" />

* A compact appearance will use the existing `ExtensionSmallResultItem`. This will also be the default for compatibility with existing users.
* A comfortable appearance will use `ExtensionResultItem` and will display the stem of the result as the prominent name and the file path as the description as proposed by #111 